### PR TITLE
Added page_action that links to the options page if on tumblr.com.

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -8,3 +8,22 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 		sendResponse({});
 	}
 });
+
+chrome.runtime.onInstalled.addListener(function() {
+  chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
+    chrome.declarativeContent.onPageChanged.addRules([
+      {
+        conditions: [
+          new chrome.declarativeContent.PageStateMatcher({
+            pageUrl: { urlContains: 'tumblr.com' },
+          })
+        ],
+        actions: [ new chrome.declarativeContent.ShowPageAction() ]
+      }
+    ]);
+  });
+});
+
+chrome.pageAction.onClicked.addListener(function(tab) {
+  chrome.tabs.create({url: "options.html"});
+});

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,9 @@
 			"js": ["js/defaults.js", "js/jquery-2.0.3.min.js", "js/content_script.js", "js/hide_formats.js"]
 		}
 	],
+	"permissions" : [
+    "declarativeContent"
+  ],
 	"web_accessible_resources": [
 		"js/jquery-2.0.3.min.map"
 	],


### PR DESCRIPTION
If on tumblr.com the icon will show up in the url bar and currently links to the options page. :boom: This is handy to get to the options page faster but also lets you know the extension is running. You can also right click on the icon and click to go to the extension page on the Chrome Web Store. 
